### PR TITLE
fix: Ensure Shodan REST API errors are returned to user

### DIFF
--- a/integration.js
+++ b/integration.js
@@ -57,7 +57,7 @@ function doLookup(entities, options, cb) {
         const [errs, results] = transpose2DArray(requestResults);
         const errors = errs.filter(
           (err) =>
-            !_.isEmpty(err) && err && err.message === 'This job has been dropped by Bottleneck'
+            !_.isEmpty(err)
         );
 
         if (errors.length) {
@@ -115,6 +115,11 @@ const requestEntity = (entity, requestOptions, callback) =>
       return callback(null, {
         entity,
         body: null
+      });
+    } else if (res.statusCode === 401) {
+      // no result found
+      return callback({
+        detail: 'Unauthorized: The provided API key is invalid.'
       });
     } else if (res.statusCode === 503) {
       // reached request limit

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "./integration.js",
   "name": "shodan",
-  "version": "3.2.2-beta",
+  "version": "3.2.3-beta",
   "private": true,
   "dependencies": {
     "bottleneck": "^2.19.5",


### PR DESCRIPTION
@penwoodjon I added in explicit handling for 401 errors (unauthorized) and removed the if statement checking to see if the error had a message `This job has been dropped by Bottleneck`.  Previously only errors that had that message were being returned to the user.  I don't think that's the logic we want though as it was dropping all the REST errors that could occur.

Let me know if that was there for a reason and we need a different fix.